### PR TITLE
Remove redirect when clearing the trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.7 (2022-08-04)
+
+Remove redirection when clearing the trailing slash in the route (solves the issue in case of POST)
+
 # 1.0.6 (2022-08-04)
 
 Disable MIME-sniffing with `x-content-type-options: NOSNIFF` ([rationale here](https://github.com/canonical/web-design-systems-squad/issues/77#issuecomment-1205100399))

--- a/canonicalwebteam/flask_base/context.py
+++ b/canonicalwebteam/flask_base/context.py
@@ -1,9 +1,9 @@
 import os
 from datetime import datetime
 from hashlib import md5
-from urllib.parse import unquote, urlparse, urlunparse
+from urllib.parse import unquote, urlparse
 
-from flask import current_app, redirect, request
+from flask import current_app, request
 
 
 def now(format):
@@ -50,6 +50,4 @@ def clear_trailing_slash():
     path = parsed_url.path
 
     if path != "/" and path.endswith("/"):
-        new_uri = urlunparse(parsed_url._replace(path=path[:-1]))
-
-        return redirect(new_uri)
+        request.url = path[:-1]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="1.0.6",
+    version="1.0.7",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."

--- a/tests/test_flask_base.py
+++ b/tests/test_flask_base.py
@@ -259,10 +259,7 @@ class TestFlaskBase(unittest.TestCase):
             self.assertEqual(200, response.status_code)
 
             response = client.get("/page/")
-            self.assertEqual(302, response.status_code)
-            self.assertEqual(
-                "http://localhost/page", response.headers.get("Location")
-            )
+            self.assertEqual(200, response.status_code)
 
     def test_static_files(self):
         flask_app = create_test_app()


### PR DESCRIPTION
## Done

- Remove the redirection
- Remove the trailing slash in the URL, so that the routes work as expected in both cases: with and without the additional trailing slash add the end of the URL
