### PR TITLE
add compression of JS and CSS assets

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: |
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install system dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       
       - name: Install system dependencies
         run: |
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check inclusive naming
         uses: canonical-web-and-design/inclusive-naming@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0 (2025-01-23)
+
+Add compression of JS and CSS assets
+
 # 2.0.0 (2024-07-04)
 
 Pin to Flask 2.3.3

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -7,6 +7,7 @@ import flask
 import talisker.flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.debug import DebuggedApplication
+from flask_squeeze import Squeeze
 
 # Local modules
 from canonicalwebteam.flask_base.context import (
@@ -242,6 +243,10 @@ class FlaskBase(flask.Flask):
         talisker.logs.set_global_extra(
             {"service": self.service, "pid": os.getpid()}
         )
+
+        # Compress JS and CSS
+        squeeze = Squeeze()
+        squeeze.init_app(self)
 
         # Default error handlers
         if template_404:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.0.0",
+    version="2.1.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."
@@ -30,6 +30,7 @@ setup(
         "Werkzeug >= 2.3.7, < 3.0.0",
         "markupsafe >= 1.0, < 2.2.0",
         "itsdangerous >= 0.24, < 2.2.0",
+        "flask-squeeze >= 3.1.0",
     ],
     dependency_links=[],
     include_package_data=True,


### PR DESCRIPTION
Compressing JS and CSS assets improves performance as they weigh less and load faster.
Used [flask-squeeze](https://github.com/mkrd/Flask-Squeeze) package for that as it seems to be the latest among other similar solutions. 