### PR TITLE
feat: added support for content-encoding

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,7 +49,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y --no-install-recommends python3-setuptools
           pip3 install --upgrade setuptools
-          pip3 install .
 
       - name: Install dependencies
         run: pip3 install .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,6 +44,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
       - name: Install system dependencies
         run: |

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -1,5 +1,4 @@
 # Standard library
-import gzip
 import hashlib
 import os
 

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -1,15 +1,12 @@
 # Standard library
+import gzip
 import hashlib
 import os
 
 # Packages
 import flask
 import talisker.flask
-from canonicalwebteam.yaml_responses.flask_helpers import (
-    prepare_deleted,
-    prepare_redirects,
-)
-from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
+from flask_compress import Compress
 from werkzeug.debug import DebuggedApplication
 
 # Local modules
@@ -18,6 +15,11 @@ from canonicalwebteam.flask_base.context import (
     clear_trailing_slash,
 )
 from canonicalwebteam.flask_base.converters import RegexConverter
+from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
+from canonicalwebteam.yaml_responses.flask_helpers import (
+    prepare_deleted,
+    prepare_redirects,
+)
 
 STATUS_CHECK = os.getenv("TALISKER_REVISION_ID", "OK")
 
@@ -148,6 +150,15 @@ def set_clacks(response):
     response.headers["X-Clacks-Overhead"] = "GNU Terry Pratchett"
 
     return response
+
+
+def set_compression_types(app):
+    """
+    Set the file types that should be compressed.
+    """
+
+    compress = Compress()
+    compress.init_app(app)
 
 
 class FlaskBase(flask.Flask):
@@ -312,3 +323,5 @@ class FlaskBase(flask.Flask):
             @self.route("/.well-known/security.txt")
             def security():
                 return flask.send_file(security_path)
+
+        set_compression_types(self)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.2.2.dev1",
+    version="2.3.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."
@@ -32,6 +32,7 @@ setup(
         "Werkzeug >= 2.3.7",
         # Use latest version of Flask once Talisker supports werkzeug >=3
         "flask==2.3.3",
+        "flask-compress==1.17",
     ],
     dependency_links=[],
     include_package_data=True,

--- a/tests/test_flask_base.py
+++ b/tests/test_flask_base.py
@@ -6,11 +6,11 @@ from contextlib import contextmanager
 
 # Packages
 import talisker.testing
-from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
 from werkzeug.debug import DebuggedApplication
 
 # Local modules
 from canonicalwebteam.flask_base.app import FlaskBase
+from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
 from tests.test_app.webapp.app import create_test_app
 
 
@@ -80,7 +80,8 @@ class TestFlaskBase(unittest.TestCase):
         with create_test_app().test_client() as client:
             cached_response_with_session = client.get("auth")
             self.assertEqual(
-                cached_response_with_session.headers.get("Vary"), "Cookie"
+                cached_response_with_session.headers.get("Vary"),
+                "Accept-Encoding, Cookie",
             )
 
     def test_cache_override(self):


### PR DESCRIPTION
## Done
- Installed [flask compress](https://github.com/colour-science/flask-compress) with default rules
[Demo PR](https://github.com/canonical/ubuntu.com/pull/14814)
## QA

- Compare the pagespeed performance for [this demo](https://pagespeed.web.dev/analysis/https-ubuntu-com-14814-demos-haus/p2xabieni9?form_factor=desktop) vs a [generic demo](https://pagespeed.web.dev/analysis/https-github-com-canonical-ubuntu-com-pull-14804/7mm2sbv44o?form_factor=desktop)

### Optional*
- Open the [demo](https://ubuntu-com-14814.demos.haus/) and check the downloaded file sizes in the dev-tools network tab
- Also check the content-encoding header on the responses, they should be encoded. Note that the encoding can vary depending on the type of document, or on the request header.

Page insights on local:
#### With compression
![image](https://github.com/user-attachments/assets/8eb60c8c-0ae3-4b31-987e-28be2be8a83b)
#### Regular
![image](https://github.com/user-attachments/assets/c3f311da-0417-478d-b8dd-07c1bfbcca34)

Fixes [WD-19898](https://warthogs.atlassian.net/browse/WD-19898)


[WD-19898]: https://warthogs.atlassian.net/browse/WD-19898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ