### PR TITLE
feat: added custom worker class

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ If you create a `security.txt`, `robots.txt` or `humans.txt` in the root of your
 
 Automatically adds the `/_status/check` endpoint which is used by content-caches for backend health checking or e.g. by k8s for checking the status of pods.
 
+### Custom gunicorn gevent worker
+
+Included is a custom gunicorn gevent worker designed to handle SIGINT and SIGTERM gracefully, by closing all client connections and logging the stacktrace before exiting.
+
+#### Usage
+Run gunicorn in the usual way, but specify the worker class as LogWorker.
+
+```bash
+talisker.gunicorn.gevent webapp.app:app \
+    -k canonicalwebteam.flask_base.worker.LogWorker
+```
+
 ## Tests
 
 To run the tests execute `SECRET_KEY=fake python3 -m unittest discover tests`.

--- a/canonicalwebteam/flask_base/__init__.py
+++ b/canonicalwebteam/flask_base/__init__.py
@@ -1,3 +1,3 @@
-from canonicalwebteam.flask_base.worker import LogWorker
+from canonicalwebteam.flask_base import worker
 
-__all__ = ["LogWorker"]
+__all__ = ["worker"]

--- a/canonicalwebteam/flask_base/__init__.py
+++ b/canonicalwebteam/flask_base/__init__.py
@@ -1,0 +1,3 @@
+from canonicalwebteam.flask_base.worker import LogWorker
+
+__all__ = ["LogWorker"]

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -9,7 +9,7 @@ exiting.
 Run gunicorn in the usual way, but specify the worker class as LogWorker.
 
 talisker.gunicorn.gevent webapp.app:app \
-    -k canonicalwebteam.flask-base.worker.LogWorker
+    -k canonicalwebteam.flask_base.worker.LogWorker
 
 """
 
@@ -60,7 +60,7 @@ class LogWorker(GeventWorker):
     def notify_error(self, sig: int) -> None:
         """Print recent traceback logs."""
         self._log(f"notifying errors with signal {sig}")
-        self._log(traceback.format_exc())
+        self._log("Stacktrace: " + traceback.format_exc())
 
     def accept(self, listener: socket) -> None:
         """Accept a new client connection."""

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -65,11 +65,6 @@ class LogWorker(GeventWorker):
     def handle(self, listener: socket, client: socket, addr: tuple) -> None:
         """Handle a new client connection."""
         # Register client connections to this worker
-        self._log(
-            f"New connection: {listener.getsockname()} "
-            f"to {client.getsockname()} "
-            f"at {addr}",
-        )  # remove after review
         self.clients.append(listener)
         super().handle(listener, client, addr)
 

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -64,6 +64,10 @@ class LogWorker(GeventWorker):
     def handle(self, listener: socket, client: socket, addr: tuple) -> None:
         """Handle a new client connection."""
         # Register client connections to this worker
+        self._log(
+            f"New connection: {listener.getsockname()} "
+            "to {client.getsockname()}",
+        )  # remove after review
         self.clients.append(listener)
         super().handle(listener, client, addr)
 

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -66,7 +66,7 @@ class LogWorker(GeventWorker):
         # Register client connections to this worker
         self._log(
             f"New connection: {listener.getsockname()} "
-            "to {client.getsockname()}",
+            f"to {client.getsockname()}",
         )  # remove after review
         self.clients.append(listener)
         super().handle(listener, client, addr)

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -1,0 +1,75 @@
+"""
+A custom gunicorn gevent worker for Flask applications.
+
+This worker is designed to handle SIGINT and SIGTERM gracefully, by
+closing all client connections and logging the stacktrace before
+exiting.
+
+## Usage
+Run gunicorn in the usual way, but specify the worker class as LogWorker.
+
+talisker.gunicorn.gevent webapp.app:app -k flask_base.worker.LogWorker
+
+"""
+
+import secrets
+import sys
+import traceback
+from typing import NoReturn
+
+from gunicorn import util
+from gunicorn.workers.ggevent import GeventWorker
+
+
+class LogWorker(GeventWorker):
+    def __init__(self, *args: tuple, **kwargs: dict) -> None:
+        super().__init__(*args, **kwargs)
+        self.instance_id = secrets.token_hex(6)
+        self.clients = []
+
+    def _log(self, msg: str) -> None:
+        print(f"[CUSTOM WORKER][{self.instance_id}]: {msg}")
+
+    def close_clients_gracefully(self) -> None:
+        """Send a 200 response to all registered clients"""
+        self._log(f"closing {len(self.clients)} clients gracefully")
+        msg = "OK"
+        size = len(msg)
+        response_data = (
+            f"HTTP/1.1 200 {msg}\r\nContent-Length: {size}\r\n\r\n{msg}"
+        )
+        response_data = response_data.encode("utf-8")
+        try:
+            for conn in self.clients:
+                conn.sendall(response_data)
+                conn.close()
+        except Exception as e:  # noqa: BLE001
+            self._log(str(e))
+
+    def notify_error(self, sig: int) -> None:
+        """Print recent traceback logs."""
+        self._log(f"notifying errors with signal {sig}")
+        self._log(traceback.format_exc())
+
+    def accept(self, listener) -> None:
+        """Accept a new client connection."""
+        client, addr = listener.accept()
+        # Register client connections to this worker
+        self.clients.append(client)
+        client.setblocking(1)
+        util.close_on_exec(client)
+        self.handle(listener, client, addr)
+
+    def handle_exit(self, sig, frame) -> None:
+        """Handle SIGTERM gracefully"""
+        self._log(f"handling signal {sig}")
+        self.notify_error(sig)
+        self.close_clients_gracefully()
+        sys.exit(0)
+
+    def handle_quit(self, sig, frame) -> NoReturn:
+        """Handle SIGQUIT gracefully"""
+        self._log(f"handling signal {sig}")
+        self.notify_error(sig)
+        self.close_clients_gracefully()
+        sys.exit(0)

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import logging
 import secrets
-import sys
 import traceback
 from typing import TYPE_CHECKING
 
@@ -74,7 +73,6 @@ class LogWorker(GeventWorker):
         self.notify_error(sig)
         self.close_clients_gracefully()
         self._log(f"closing worker {self.instance_id}")
-        sys.exit(0)
 
     def handle_quit(self, sig: int, frame: FrameType | None) -> None:
         """Handle SIGQUIT gracefully"""
@@ -82,7 +80,6 @@ class LogWorker(GeventWorker):
         self.notify_error(sig)
         self.close_clients_gracefully()
         self._log(f"closing worker {self.instance_id}")
-        sys.exit(0)
 
     def handle_interrupt(self, sig: int, frame: FrameType | None) -> None:
         """Handle SIGINT gracefully"""
@@ -90,4 +87,3 @@ class LogWorker(GeventWorker):
         self.notify_error(sig)
         self.close_clients_gracefully()
         self._log(f"closing worker {self.instance_id}")
-        sys.exit(0)

--- a/canonicalwebteam/flask_base/worker.py
+++ b/canonicalwebteam/flask_base/worker.py
@@ -66,7 +66,8 @@ class LogWorker(GeventWorker):
         # Register client connections to this worker
         self._log(
             f"New connection: {listener.getsockname()} "
-            f"to {client.getsockname()}",
+            f"to {client.getsockname()} "
+            f"at {addr}",
         )  # remove after review
         self.clients.append(listener)
         super().handle(listener, client, addr)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.2.2.dev1",
+    version="2.5.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
## Done
- Added a custom gevent worker class, which closes open connections and logs the stacktrace when it receives a `SIGINT` or `SIGTERM` signal.

## QA
- Clone the demo [branch](https://github.com/canonical/canonical.com/tree/samhotep-patch-2), and start the service using `dotrun`
- In a separate terminal, get the `pids` of the running workers, and send `SIGINT` and `SIGTERM` signals using
#### Either
`Ctrl+C` in the dotrun terminal
#### Or
```bash
ps -a | grep talisker # in the dotrun container
kill -15 <pid>
```
- In the first shell, the server logs should have the custom worker's logs, e.g
```
2025-04-09 16:54:09.158Z INFO gunicorn.error "[LOG WORKER][3cdffceadbd9]: handling signal 15"
```
- I've added a test endpoint to the branch which allows checking whether the connections are indeed closed.
Download the handy [hey](https://github.com/rakyll/hey?tab=readme-ov-file) binary, and while the canonical.com project is running (on port 8002 in this example), do:
```bash
./hey_linux_amd64 -n 10 -c 10 -h2 http://0.0.0.0:8002/test/long_running
```
This will run for about 100s. While this is running, do
#### Either
`Ctrl+C` in the dotrun terminal
#### Or
```bash
ps -a | grep talisker # in the dotrun container
kill -15 <pid>
```
- In the first shell, the server logs should show the count of open connections
```
2025-04-09 16:51:51.487Z INFO gunicorn.error "[LOG WORKER][b86f7225f43a]: closing 10 clients gracefully"
```
- Check the terminal running `hey_linux_amd`. The connections should have dropped, and a report should be shown

### Fixes [WD-16674](https://warthogs.atlassian.net/browse/WD-16674)

[WD-16674]: https://warthogs.atlassian.net/browse/WD-16674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ