### PR TITLE
Add flask secret key

### DIFF
--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -214,8 +214,13 @@ class FlaskBase(flask.Flask):
 
         self.service = service
 
-        self.config["SECRET_KEY"] = get_flask_env("SECRET_KEY")
+        # Ensure that either SECRET_KEY or FLASK_SECRET_KEY is set
+        self.config["SECRET_KEY"] = get_flask_env("SECRET_KEY", error=True)
+        # Load environment variables prefixed with 'FLASK_' into the
+        # environment as regular variables
         load_plain_env_variables()
+        # Load environment variables prefixed with 'FLASK_' into the config
+        self.config.from_prefixed_env()
 
         self.url_map.strict_slashes = False
         self.url_map.converters["regex"] = RegexConverter

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -14,6 +14,7 @@ from canonicalwebteam.flask_base.context import (
     clear_trailing_slash,
 )
 from canonicalwebteam.flask_base.converters import RegexConverter
+from canonicalwebteam.flask_base.env import get_flask_env
 from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
 from canonicalwebteam.yaml_responses.flask_helpers import (
     prepare_deleted,
@@ -204,13 +205,13 @@ class FlaskBase(flask.Flask):
         template_404=None,
         template_500=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(name, *args, **kwargs)
 
         self.service = service
 
-        self.config["SECRET_KEY"] = os.environ["SECRET_KEY"]
+        self.config["SECRET_KEY"] = get_flask_env("SECRET_KEY")
 
         self.url_map.strict_slashes = False
         self.url_map.converters["regex"] = RegexConverter

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -14,7 +14,10 @@ from canonicalwebteam.flask_base.context import (
     clear_trailing_slash,
 )
 from canonicalwebteam.flask_base.converters import RegexConverter
-from canonicalwebteam.flask_base.env import get_flask_env
+from canonicalwebteam.flask_base.env import (
+    get_flask_env,
+    load_plain_env_variables,
+)
 from canonicalwebteam.flask_base.middlewares.proxy_fix import ProxyFix
 from canonicalwebteam.yaml_responses.flask_helpers import (
     prepare_deleted,
@@ -212,6 +215,7 @@ class FlaskBase(flask.Flask):
         self.service = service
 
         self.config["SECRET_KEY"] = get_flask_env("SECRET_KEY")
+        load_plain_env_variables()
 
         self.url_map.strict_slashes = False
         self.url_map.converters["regex"] = RegexConverter

--- a/canonicalwebteam/flask_base/env.py
+++ b/canonicalwebteam/flask_base/env.py
@@ -1,0 +1,8 @@
+from os import environ
+
+
+def get_flask_env(key: str, default=None) -> str | None:
+    """Return the value of KEY or FLASK_KEY, otherwise, return
+    a default.
+    """
+    return environ.get(key, environ.get(f"FLASK_{key}", default))

--- a/canonicalwebteam/flask_base/env.py
+++ b/canonicalwebteam/flask_base/env.py
@@ -6,3 +6,18 @@ def get_flask_env(key: str, default=None) -> str | None:
     a default.
     """
     return environ.get(key, environ.get(f"FLASK_{key}", default))
+
+
+def load_plain_env_variables() -> None:
+    """Load environment variables prefixed with 'FLASK_' from the environment,
+    and update the environment with the plain variables.
+    """
+    flask_env_vars = {}
+    for k, v in environ.items():
+        # Filter for variables that exist and start with 'FLASK_'
+        if k.startswith("FLASK_") and v:
+            # Remove the 'FLASK_' prefix and update the environment
+            flask_env_vars[k[6:]] = v
+
+    # Update the environment with the plain variables
+    environ.update(flask_env_vars)

--- a/canonicalwebteam/flask_base/env.py
+++ b/canonicalwebteam/flask_base/env.py
@@ -1,16 +1,25 @@
 from os import environ
 
 
-def get_flask_env(key: str, default=None) -> str | None:
+def get_flask_env(key: str, default=None, error=False) -> str | None:
     """Return the value of KEY or FLASK_KEY, otherwise, return
     a default.
+    If neither is found and error is True, raise a KeyError.
+
+    :param key: The environment variable key to look for.
+    :param default: The default value to return if the key is not found.
+    :param error: If True, raise a KeyError if the key is not found.
     """
-    return environ.get(key, environ.get(f"FLASK_{key}", default))
+    value = environ.get(key, environ.get(f"FLASK_{key}", default))
+    if not value and error:
+        message = f"Environment variable '{key}' not found."
+        raise KeyError(message)
+    return value
 
 
 def load_plain_env_variables() -> None:
     """Load environment variables prefixed with 'FLASK_' from the environment,
-    and update the environment with the plain variables.
+    strip the prefix and update the environment with the plain variables.
     """
     flask_env_vars = {}
     for k, v in environ.items():

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.5.0",
+    version="2.6.0",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
## Done
- Ensured the secret key is set, either as SECRET_KEY or FLASK_SECRET_KEY
- Loaded prefixed env variables into the config automatically
- Loaded prefixed env variables into the environment as plain variables (This means we don't have to rename variables to use them in the charm)

## QA
- Here's a [demo](https://ubuntu-com-15225.demos.haus/) with the flask base updates. I've added a new variable to the environment via k8s, FLASK_TEST_ENV, whose value is `testvalue`. Check that the demo runs as expected.
  - Open https://ubuntu-com-15225.demos.haus/testflaskbase and confirm that the value returned is indeed `testvalue`.