### PR TITLE
feat: added compression override option

### DIFF
--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -154,40 +154,14 @@ def set_clacks(response):
 
     return response
 
-DEFAULT_COMPRESS_MIMETYPES = [
-    'text/html',
-    'text/css',
-    'text/plain',
-    'text/xml',
-    'text/x-component',
-    'text/javascript',
-    'application/x-javascript',
-    'application/javascript',
-    'application/json',
-    'application/manifest+json',
-    'application/vnd.api+json',
-    'application/xml',
-    'application/xhtml+xml',
-    'application/rss+xml',
-    'application/atom+xml',
-    'application/vnd.ms-fontobject',
-    'application/x-font-ttf',
-    'application/x-font-opentype',
-    'application/x-font-truetype',
-    'image/svg+xml',
-    'image/x-icon',
-    'image/vnd.microsoft.icon',
-    'font/ttf',
-    'font/eot',
-    'font/otf',
-    'font/opentype',
-]
 
 def set_compression_types(app, compress_mimetypes):
     """
     Set the file types that should be compressed.
     """
-    app.config['COMPRESS_MIMETYPES'] = compress_mimetypes or DEFAULT_COMPRESS_MIMETYPES
+
+    if compress_mimetypes:
+        app.config['COMPRESS_MIMETYPES'] = compress_mimetypes
     compress = Compress()
     compress.init_app(app)
 

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -161,7 +161,7 @@ def set_compression_types(app, compress_mimetypes):
     """
 
     if compress_mimetypes:
-        app.config['COMPRESS_MIMETYPES'] = compress_mimetypes
+        app.config["COMPRESS_MIMETYPES"] = compress_mimetypes
     compress = Compress()
     compress.init_app(app)
 

--- a/canonicalwebteam/flask_base/app.py
+++ b/canonicalwebteam/flask_base/app.py
@@ -154,12 +154,40 @@ def set_clacks(response):
 
     return response
 
+DEFAULT_COMPRESS_MIMETYPES = [
+    'text/html',
+    'text/css',
+    'text/plain',
+    'text/xml',
+    'text/x-component',
+    'text/javascript',
+    'application/x-javascript',
+    'application/javascript',
+    'application/json',
+    'application/manifest+json',
+    'application/vnd.api+json',
+    'application/xml',
+    'application/xhtml+xml',
+    'application/rss+xml',
+    'application/atom+xml',
+    'application/vnd.ms-fontobject',
+    'application/x-font-ttf',
+    'application/x-font-opentype',
+    'application/x-font-truetype',
+    'image/svg+xml',
+    'image/x-icon',
+    'image/vnd.microsoft.icon',
+    'font/ttf',
+    'font/eot',
+    'font/otf',
+    'font/opentype',
+]
 
-def set_compression_types(app):
+def set_compression_types(app, compress_mimetypes):
     """
     Set the file types that should be compressed.
     """
-
+    app.config['COMPRESS_MIMETYPES'] = compress_mimetypes or DEFAULT_COMPRESS_MIMETYPES
     compress = Compress()
     compress.init_app(app)
 
@@ -207,6 +235,7 @@ class FlaskBase(flask.Flask):
         favicon_url=None,
         template_404=None,
         template_500=None,
+        compress_mimetypes=(),
         *args,
         **kwargs,
     ):
@@ -333,4 +362,4 @@ class FlaskBase(flask.Flask):
             def security():
                 return flask.send_file(security_path)
 
-        set_compression_types(self)
+        set_compression_types(self, compress_mimetypes)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="2.6.0",
+    version="2.6.1",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
## Problem
We need a way to prevent compression on just json responses on the security api, as the pro client is having trouble decoding brotli encoded responses. The library doesn't allow us to cleanly override default options once the app has loaded, so we have to set these at initialization time.

## Done
- Added an option to override the default compression options.

## QA
- Here's a [PR](https://github.com/canonical/ubuntu-com-security-api/pull/206) to test the changes on the security API
