### PR TITLE
WD-26946 - Fix missing opentelemetry module in published version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.1.1 (2025-10-08)
+
+Add missing init file to fix the bug of missing opentelemetry module.
+
 # 3.1.0 (2025-09-24)
 
 - Add prettified logs to Development mode.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="canonicalwebteam.flask-base",
-    version="3.1.0",
+    version="3.1.1",
     description=(
         "Flask extension that applies common configurations"
         "to all of webteam's flask apps."


### PR DESCRIPTION
Add missing empty init file because otherwise the published version in PyPi doesn't include the opentelemetry module.